### PR TITLE
chore(release): bump package versions

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,6 +10,14 @@
     "lint": "eslint . --cache --cache-location .cache/.eslintcache",
     "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/halvaradop/configs.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/eslint-config"
+  },
   "keywords": [
     "eslint",
     "config",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -10,6 +10,14 @@
     "lint": "eslint . --cache --cache-location .cache/.eslintcache",
     "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/halvaradop/configs.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/prettier-config"
+  },
   "keywords": [
     "prettier",
     "config",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -8,6 +8,14 @@
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/halvaradop/configs.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/tsconfig"
+  },
   "keywords": [
     "typescript",
     "tsconfig",

--- a/packages/tsup-config/package.json
+++ b/packages/tsup-config/package.json
@@ -10,6 +10,14 @@
     "lint": "eslint . --cache --cache-location .cache/.eslintcache",
     "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/halvaradop/configs.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/tsup-config"
+  },
   "keywords": [
     "tsup",
     "typescript",


### PR DESCRIPTION
## Description

This pull request bumps package versions to npm to their first version. The packages included are


- `halvaradop/eslint-config`
- `halvaradop/prettier-config`
- `halvaradop/tsconfig`
- `halvaradop/tsup-config`

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
