### PR TITLE
feat(prettier-config): support ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "check-types": "turbo run check-types"
   },
   "devDependencies": {
-    "@halvaradop/prettier-config": "workspace:*",
     "@halvaradop/eslint-config": "workspace:*",
+    "@halvaradop/prettier-config": "workspace:*",
     "prettier": "^3.6.2",
+    "tsup": "^8.3.6",
     "turbo": "^2.5.5",
     "typescript": "5.8.3"
   },
   "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": ">=18"
-  },
-  "prettier": "@halvaradop/prettier-config"
+  }
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -4,11 +4,15 @@
   "private": false,
   "description": "Shared Prettier configuration for all @halvaradop projects.",
   "type": "module",
+  "main": "dist/prettier.config.js",
+  "types": "dist/prettier.config.d.ts",
   "scripts": {
+    "build": "tsup prettier.config.js && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint . --cache --cache-location .cache/.eslintcache",
-    "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache"
+    "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache",
+    "clean:cts": "rm -rf ./dist/*.d.cts"
   },
   "repository": {
     "type": "git",
@@ -27,11 +31,10 @@
   ],
   "author": "Hernan Alvarado <hernanvid123@gmail.com>",
   "license": "MIT",
-  "exports": {
-    ".": "./prettier.config.js"
-  },
   "devDependencies": {
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "@halvaradop/tsconfig": "workspace:*",
+    "@halvaradop/tsup-config": "workspace:*"
   },
   "peerDependencies": {
     "prettier": "^2.0.0"

--- a/packages/prettier-config/tsup.config.js
+++ b/packages/prettier-config/tsup.config.js
@@ -1,0 +1,4 @@
+import { defineConfig } from "tsup"
+import { tsupConfig } from "@halvaradop/tsup-config"
+
+export default defineConfig(tsupConfig)

--- a/packages/tsup-config/package.json
+++ b/packages/tsup-config/package.json
@@ -5,11 +5,12 @@
   "description": "Reusable tsup build configuration for @halvaradop projects.",
   "type": "module",
   "scripts": {
-    "build": "tsup tsup.config.ts",
+    "build": "tsup tsup.config.js && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint . --cache --cache-location .cache/.eslintcache",
-    "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache"
+    "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache",
+    "clean:cts": "rm -rf ./dist/*.d.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/tsup-config/tsconfig.json
+++ b/packages/tsup-config/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": "@halvaradop/tsconfig/tsconfig.base.json",
-  "compilerOptions": {},
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", ".turbo", ".cache"]
-}

--- a/packages/tsup-config/tsup.config.js
+++ b/packages/tsup-config/tsup.config.js
@@ -1,6 +1,7 @@
-import type { Options } from "tsup"
-
-export const tsupConfig: Options = {
+/**
+ * @type {import("tsup").Options}
+ */
+export const tsupConfig = {
     format: ["esm", "cjs"],
     dts: true,
     clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      tsup:
+        specifier: ^8.3.6
+        version: 8.5.0(typescript@5.8.3)
       turbo:
         specifier: ^2.5.5
         version: 2.5.5
@@ -68,6 +71,12 @@ importers:
 
   packages/prettier-config:
     devDependencies:
+      '@halvaradop/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@halvaradop/tsup-config':
+        specifier: workspace:*
+        version: link:../tsup-config
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -1502,6 +1511,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+import { config } from "@halvaradop/prettier-config"
+
+/**
+ * @type {import("prettier").Config}
+ */
+export default config

--- a/turbo.json
+++ b/turbo.json
@@ -3,8 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": ["dist"]
     },
     "lint": {
       "dependsOn": ["^lint"],


### PR DESCRIPTION
## Description

This pull request updates the **Prettier** configuration to be written in TypeScript, providing native support for both JavaScript and TypeScript projects.  

Previously, the configuration could only be executed from a `.js` file because the `types` were not included in the bundle. With this update, the types are now bundled, enabling support for both `.js` and `.ts` configuration files.

> [!NOTE]  
> The `exports` field in `package.json` is not fully compatible with Prettier.  
> For this reason, the `main` and `types` fields were explicitly defined in `package.json`.

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code.
- [x] All tests have been added and pass successfully.

## Notes

<!-- Add any additional relevant information here -->
